### PR TITLE
Fix typo "From" => "FROM"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-From alpine:edge
+FROM alpine:edge
 
 ADD run /
 ADD https://raw.githubusercontent.com/mvertes/dosu/0.1.0/dosu /sbin/


### PR DESCRIPTION
Hi. Fix this typo because of main convention about naming "keys" in Dockerfile.