### PR TITLE
make run.sh executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,7 @@ VOLUME /data/db
 EXPOSE 27017 28017
 
 COPY run.sh /root
+RUN chmod +x /root/run.sh
+
 ENTRYPOINT [ "/root/run.sh" ]
 CMD [ "mongod" ]


### PR DESCRIPTION
I was using docker-compose with  this Dockerfile and found permission denied on `/root/run.sh` when executed with `ENTRYPOINT`

`ERROR: for mongodb  Cannot start service mongodb: invalid header field value "oci runtime error: container_linux.go:247: starting container process caused \"exec: \\\"/root/run.sh\\\": permission denied\"\n"`

Add `chmod +x` to fix it. 