### PR TITLE
Fix typo `monogo` -> `mongo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To use the mongo shell client:
 
 The mongo shell client can also be run its own container: 
 
-	$ docker run -ti --rm --name mongoshell monogo host:port/db
+	$ docker run -ti --rm --name mongoshell mongo host:port/db
 
 ## Limitations
 


### PR DESCRIPTION
Hello @mvertes I did not know how to tell you about this typo so I made this PR. :sweat_smile: I hope you're having a good day :)

(Also my first contrib on a repo, non work related) (:+1: 